### PR TITLE
feat: Add loading spinner during data collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ thiserror = "2.0"
 # Utilities
 dirs = "5.0"
 
+# Progress indicator
+indicatif = "0.18.3"
+
 [dev-dependencies]
 tempfile = "3.14"
 assert_cmd = "2.0"


### PR DESCRIPTION
## Summary
- TUI モードでデータ読み込み中にスピナーを表示
- indicatif 0.18.3 を使用
- SpinnerGuard (RAII) でエラー時も確実にクリーンアップ

## Changes
- `Cargo.toml`: indicatif 依存追加
- `src/cli/run.rs`: SpinnerGuard 実装とスピナー表示

## Test plan
- [x] `cargo test` パス
- [x] `cargo clippy` パス
- [ ] `cargo run` でスピナー表示を確認
- [ ] `cargo run -- -o json` でスピナー非表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)