### PR TITLE
chore: Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-02-08
+
+### Added
+
+- `kodo list` subcommand to display registered repositories
+- Loading spinner during data collection
+- Diverging bar chart for Additions/Deletions (replacing separate charts)
+- Vertical scroll support for Add/Del diverging bar chart
+
+### Changed
+
+- Added kodo-release skill for automated releases
+- Added release workflow documentation
+
 ## [0.3.0] - 2026-02-08
 
 ### Added
@@ -49,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/yumazak/kodo/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/yumazak/kodo/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/yumazak/kodo/releases/tag/v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kodo"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.93"
 authors = ["yumazak"]


### PR DESCRIPTION
## Release v0.4.0

### Changes

#### Added
- `kodo list` subcommand to display registered repositories
- Loading spinner during data collection
- Diverging bar chart for Additions/Deletions (replacing separate charts)
- Vertical scroll support for Add/Del diverging bar chart

#### Changed
- Added kodo-release skill for automated releases
- Added release workflow documentation

### Checklist
- [ ] CI passes
- [ ] Version in Cargo.toml is correct
- [ ] CHANGELOG.md is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)