### PR TITLE
docs: Remove update instructions pending mise upgrade verification

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,31 +41,6 @@ cargo install kodo
 cargo install --path .
 ```
 
-## アップデート
-
-### mise
-
-```bash
-mise upgrade kodo
-```
-
-### crates.io
-
-```bash
-cargo install kodo
-```
-
-### リリースから
-
-[Releases](https://github.com/yumazak/kodo/releases) ページから最新バイナリをダウンロードし、既存のものと置き換えてください。
-
-### ソースから
-
-```bash
-git pull
-cargo install --path .
-```
-
 ## 使い方
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,31 +41,6 @@ Download the appropriate binary for your platform from the [Releases](https://gi
 cargo install --path .
 ```
 
-## Updating
-
-### mise
-
-```bash
-mise upgrade kodo
-```
-
-### crates.io
-
-```bash
-cargo install kodo
-```
-
-### From Releases
-
-Download the latest binary from the [Releases](https://github.com/yumazak/kodo/releases) page and replace the existing one.
-
-### From Source
-
-```bash
-git pull
-cargo install --path .
-```
-
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- README.md と README.ja.md から「Updating」/「アップデート」セクションを削除
- mise の `mise upgrade kodo` コマンドの動作が未確認のため、一旦削除

## Background
TASK-13 でアップデート手順を追加しましたが、mise の upgrade コマンドが正しく動作するか確認できていないため、誤った情報を掲載しないよう削除しました。動作確認ができ次第、再度追加予定です。

## Changes
- 両 README から 24 行の update instructions セクションを削除

Resolves TASK-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)