### PR TITLE
feat: Expand Single mode to support all 5 chart types

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,4 +5,4 @@ pub mod event;
 pub mod ui;
 pub mod widgets;
 
-pub use app::{App, Metric};
+pub use app::{App, ChartType, Metric};

--- a/src/tui/widgets/line_chart.rs
+++ b/src/tui/widgets/line_chart.rs
@@ -6,11 +6,6 @@ use crate::tui::app::{App, Metric};
 use ratatui::prelude::*;
 use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, Paragraph};
 
-/// Render a line chart for current metric
-pub fn render_line_chart(frame: &mut Frame, area: Rect, app: &App) {
-    render_line_chart_for_metric(frame, area, app, app.metric);
-}
-
 /// Render a line chart for a specific metric
 pub fn render_line_chart_for_metric(frame: &mut Frame, area: Rect, app: &App, metric: Metric) {
     let values = app.values_for_metric(metric);

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -7,5 +7,5 @@ mod vertical_bar_chart;
 
 pub use diverging_bar_chart::render_diverging_bar_chart;
 pub use horizontal_bar_chart::{BarDataPoint, render_horizontal_bar_chart};
-pub use line_chart::{render_line_chart, render_line_chart_for_metric};
+pub use line_chart::render_line_chart_for_metric;
 pub use vertical_bar_chart::render_vertical_bar_chart;


### PR DESCRIPTION
## Summary
- Add `ChartType` enum with 5 chart types (Commits, FilesChanged, AddDel, Weekday, Hour)
- Single mode now cycles through all charts with Tab/Arrow keys
- Add `can_scroll()` to enable scrolling only for AddDel chart in single mode
- Remove unused `App.metric` field and `render_line_chart` function
- Update footer to show current chart name in single mode

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes (99 tests)
- [ ] Manual test: Launch `kodo`, press `m` to switch to Single mode, use Tab to cycle through 5 charts
- [ ] Manual test: Verify scroll works only in AddDel chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)