### PR TITLE
feat: Add criterion benchmark for git2 stats collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/spec.md
 
 # mise
 .mise.local.toml
+
+# samply profile
+profile.json.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,11 @@ indicatif = "0.18.3"
 tempfile = "3.14"
 assert_cmd = "2.0"
 predicates = "3.1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "git_stats"
+harness = false
 
 [profile.release]
 lto = true

--- a/benches/git_stats.rs
+++ b/benches/git_stats.rs
@@ -1,0 +1,152 @@
+//! Benchmark for git statistics collection
+//!
+//! Run with: `cargo bench`
+//!
+//! Repository selection (in order of priority):
+//! 1. First repository from ~/.config/kodo/config.json
+//! 2. Environment variable `KODO_BENCH_REPO`
+//! 3. Current directory (.)
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use kodo::cli::args::Period;
+use kodo::config::{default_config_path, expand_tilde, load_config};
+use kodo::git::Repository;
+use kodo::stats::{DateRange, Days, collect_stats};
+use std::env;
+use std::path::PathBuf;
+
+/// Configuration for benchmarks
+struct BenchmarkConfig {
+    repo_path: PathBuf,
+    repo_name: String,
+}
+
+impl BenchmarkConfig {
+    /// Load benchmark configuration
+    ///
+    /// Priority:
+    /// 1. First repository from ~/.config/kodo/config.json
+    /// 2. Environment variable `KODO_BENCH_REPO`
+    /// 3. Current directory (.)
+    fn load() -> Self {
+        // Try config.json first
+        if let Some(config_path) = default_config_path()
+            && let Ok(config) = load_config(&config_path)
+            && let Some(repo) = config.repositories.first()
+        {
+            let repo_path = expand_tilde(&repo.path);
+            return Self {
+                repo_path,
+                repo_name: repo.name.clone(),
+            };
+        }
+
+        // Try environment variable
+        if let Ok(path) = env::var("KODO_BENCH_REPO") {
+            let repo_path = expand_tilde(&PathBuf::from(&path));
+            let repo_name = repo_path.file_name().map_or_else(
+                || "benchmark-repo".to_string(),
+                |n| n.to_string_lossy().to_string(),
+            );
+            return Self {
+                repo_path,
+                repo_name,
+            };
+        }
+
+        // Fallback to current directory
+        Self {
+            repo_path: PathBuf::from("."),
+            repo_name: "current-dir".to_string(),
+        }
+    }
+}
+
+/// Benchmark `Repository::commits_in_range` with different day ranges
+fn bench_commits_in_range(c: &mut Criterion) {
+    let config = BenchmarkConfig::load();
+
+    let repo = Repository::open(&config.repo_path, &config.repo_name).unwrap_or_else(|e| {
+        panic!(
+            "Failed to open repository at {}: {}",
+            config.repo_path.display(),
+            e
+        )
+    });
+
+    println!(
+        "Benchmarking repository: {} ({})",
+        config.repo_name,
+        config.repo_path.display()
+    );
+
+    let mut group = c.benchmark_group("commits_in_range");
+
+    for days in [7, 30, 90] {
+        group.bench_with_input(BenchmarkId::new("days", days), &days, |b, &days| {
+            let range = DateRange::last_n_days(Days::new(days));
+            b.iter(|| {
+                repo.commits_in_range(
+                    black_box(range.from),
+                    black_box(range.to),
+                    None,
+                    true, // exclude merges
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark `collect_stats` function
+fn bench_collect_stats(c: &mut Criterion) {
+    let config = BenchmarkConfig::load();
+
+    let repo = Repository::open(&config.repo_path, &config.repo_name).unwrap_or_else(|e| {
+        panic!(
+            "Failed to open repository at {}: {}",
+            config.repo_path.display(),
+            e
+        )
+    });
+
+    // Pre-fetch commits for 30 days
+    let range = DateRange::last_n_days(Days::new(30));
+    let commits = repo
+        .commits_in_range(range.from, range.to, None, true)
+        .expect("Failed to fetch commits");
+
+    println!("Benchmarking collect_stats with {} commits", commits.len());
+
+    let mut group = c.benchmark_group("collect_stats");
+
+    group.bench_function("daily", |b| {
+        b.iter(|| {
+            collect_stats(
+                black_box(&config.repo_name),
+                black_box(commits.clone()),
+                black_box(range),
+                black_box(Period::Daily),
+                None,
+            )
+        });
+    });
+
+    group.bench_function("weekly", |b| {
+        b.iter(|| {
+            collect_stats(
+                black_box(&config.repo_name),
+                black_box(commits.clone()),
+                black_box(range),
+                black_box(Period::Weekly),
+                None,
+            )
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_commits_in_range, bench_collect_stats);
+criterion_main!(benches);

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -1,0 +1,132 @@
+# Benchmarking Guide
+
+This document describes how to run performance benchmarks for kodo.
+
+## Prerequisites
+
+- Rust toolchain (1.93+)
+- A git repository to benchmark against
+
+## Quick Start
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Run specific benchmark group
+cargo bench -- commits_in_range
+cargo bench -- collect_stats
+```
+
+## Repository Selection
+
+Benchmarks use the following priority for selecting a repository:
+
+1. **config.json** - First repository from `~/.config/kodo/config.json`
+2. **Environment variable** - `KODO_BENCH_REPO=/path/to/repo`
+3. **Current directory** - Falls back to `.`
+
+### Using a specific repository
+
+```bash
+KODO_BENCH_REPO=/path/to/large/repo cargo bench
+```
+
+## Available Benchmarks
+
+### commits_in_range
+
+Measures `Repository::commits_in_range()` performance with different day ranges.
+
+```bash
+# All day ranges (7, 30, 90)
+cargo bench -- commits_in_range
+
+# Specific day range
+cargo bench -- commits_in_range/7
+cargo bench -- commits_in_range/30
+cargo bench -- commits_in_range/90
+```
+
+### collect_stats
+
+Measures `collect_stats()` function with daily and weekly aggregation.
+
+```bash
+cargo bench -- collect_stats
+cargo bench -- collect_stats/daily
+cargo bench -- collect_stats/weekly
+```
+
+## Benchmark Reports
+
+HTML reports are generated in `target/criterion/`. Open `target/criterion/report/index.html` in a browser to view detailed results.
+
+### Comparing results
+
+```bash
+# Save baseline
+cargo bench -- --save-baseline main
+
+# Compare against baseline
+cargo bench -- --baseline main
+```
+
+## Profiling with samply
+
+For detailed profiling, use [samply](https://github.com/mstange/samply).
+
+### Installation
+
+```bash
+cargo install samply
+```
+
+### Usage
+
+```bash
+# Build benchmark binary with debug symbols
+CARGO_PROFILE_BENCH_DEBUG=true cargo build --release --bench git_stats
+
+# Profile (choose one)
+samply record target/release/deps/git_stats-* --bench commits_in_range/7
+samply record target/release/deps/git_stats-* --bench commits_in_range/30
+samply record target/release/deps/git_stats-* --bench commits_in_range/90
+samply record target/release/deps/git_stats-* --bench collect_stats/daily
+samply record target/release/deps/git_stats-* --bench collect_stats/weekly
+```
+
+This opens Firefox Profiler in your browser with the profiling results.
+
+## Tips
+
+- Use a large repository (1000+ commits) for more accurate benchmarks
+- Run benchmarks multiple times to ensure consistent results
+- Close other applications to reduce noise
+- Use `--warm-up-time` and `--measurement-time` for more samples:
+
+```bash
+cargo bench -- --warm-up-time 5 --measurement-time 10
+```
+
+## Troubleshooting
+
+### "Gnuplot not found"
+
+This is just a warning. Criterion falls back to the plotters backend automatically.
+
+### Benchmark takes too long
+
+Use a smaller day range or filter to specific benchmarks:
+
+```bash
+cargo bench -- commits_in_range/7
+```
+
+### Repository not found
+
+Ensure `~/.config/kodo/config.json` exists and contains valid repositories, or set `KODO_BENCH_REPO`:
+
+```bash
+KODO_BENCH_REPO=. cargo bench
+```


### PR DESCRIPTION
## Summary

- Add criterion benchmark framework to measure git2 stats collection performance
- Benchmark `commits_in_range` with 7/30/90 day ranges
- Benchmark `collect_stats` with daily/weekly aggregation
- Use repository from config.json or `KODO_BENCH_REPO` env var
- Add docs/bench.md with usage instructions and samply profiling guide

## Test plan

- [x] `cargo bench --no-run` compiles successfully
- [x] `cargo bench` runs and outputs results
- [ ] Verify docs/bench.md instructions work

Closes TASK-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)