### PR TITLE
docs: Add versioning guide and migrate to GitHub Issues

### DIFF
--- a/.claude/skills/kodo-release/SKILL.md
+++ b/.claude/skills/kodo-release/SKILL.md
@@ -201,6 +201,7 @@ gh release view v${NEW_VERSION}
 
 ## 関連ドキュメント
 
+- [docs/versioning.md](../../../docs/versioning.md) - バージョン管理運用ガイド
 - [RELEASING.md](../../../RELEASING.md)
 - [CHANGELOG.md](../../../CHANGELOG.md)
 - [.github/workflows/release.yml](../../../.github/workflows/release.yml)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,72 @@
+# Versioning Guide
+
+## Semantic Versioning
+
+kodo follows [Semantic Versioning 2.0.0](https://semver.org/).
+
+### Version Format: MAJOR.MINOR.PATCH
+
+| Type | Example | Description |
+|------|---------|-------------|
+| MAJOR | 1.0.0 → 2.0.0 | Breaking changes (no API compatibility) |
+| MINOR | 0.5.0 → 0.6.0 | New features (backwards compatible) |
+| PATCH | 0.5.0 → 0.5.1 | Bug fixes and performance improvements only |
+
+### 0.x.x Era (Current)
+
+0.x.x means "in development" - API stability is not guaranteed before 1.0.0.
+
+| Version | Allowed Changes |
+|---------|-----------------|
+| 0.MINOR.0 | New features + minor breaking changes |
+| 0.MINOR.PATCH | Bug fixes, documentation, performance improvements only |
+
+### 1.0.0 Release Criteria
+
+- Core features are complete
+- API is stable
+- Documentation is comprehensive
+
+## Release Flow
+
+1. Develop on feature branch
+2. Create PR → merge to main
+3. Update CHANGELOG.md
+4. Run `/kodo-release` skill
+5. GitHub Release auto-generated
+
+## GitHub Issues Workflow
+
+### Labels
+
+| Label | Purpose |
+|-------|---------|
+| `enhancement` | New feature |
+| `bug` | Bug fix |
+| `documentation` | Documentation |
+| `type:perf` | Performance improvement |
+| `priority:high` | High priority |
+| `priority:medium` | Medium priority |
+| `priority:low` | Low priority |
+| `good first issue` | Good for newcomers |
+
+### Milestones
+
+| Milestone | Purpose |
+|-----------|---------|
+| `0.x.0` | Features for next minor release |
+| `0.x.1` | Urgent hotfix (created as needed) |
+| `Backlog` | Low priority / timing undecided |
+
+### Creating Issues
+
+```bash
+# From CLI
+gh issue create --title "Title" --body "Description" --label "enhancement,priority:medium" --milestone "0.6.0"
+
+# Or use GitHub Web UI
+```
+
+### Linking PRs and Issues
+
+Include `Fixes #123` in PR description to auto-close the issue on merge.


### PR DESCRIPTION
## Summary
- Add `docs/versioning.md` with semantic versioning guidelines
- Migrate task management from Backlog.md to GitHub Issues
- Update kodo-release skill with versioning.md reference

## Changes
- Created GitHub Labels: `priority:high/medium/low`, `type:perf`
- Created GitHub Milestones: `0.6.0`, `Backlog`
- Migrated 7 open tasks to GitHub Issues (#15-21)
- Added versioning documentation

## Test plan
- [x] Labels created and visible in GitHub
- [x] Milestones created with correct issues assigned
- [x] docs/versioning.md is readable and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)