### PR TITLE
docs: Add CLAUDE.md for AI assistant guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project Guidelines
+
+## Development Workflow
+
+- Always create a feature branch before starting work (never commit directly to main)
+- Use `gh issue create` or GitHub Web UI for tracking improvements and issues
+  - Set appropriate labels (`priority:*`, `type:*`, `enhancement`, `bug`, etc.)
+  - Set appropriate milestone (`0.x.0` or `Backlog`)
+
+## Code Quality
+
+- For complex or high-difficulty tasks, warn the user and ask for confirmation
+  - Consider the risk/reward balance
+  - Avoid features that are difficult to implement but provide little value
+
+## References
+
+- [docs/versioning.md](docs/versioning.md) - Versioning and release guidelines
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
+- [RELEASING.md](RELEASING.md) - Release process


### PR DESCRIPTION
## Summary
- Add public `CLAUDE.md` with project guidelines for AI assistants
- Migrated from private `CLAUDE.local.md` (which remains for local-only settings)

## Contents
- Development workflow (feature branches, GitHub Issues)
- Code quality considerations (risk/reward balance)
- References to key documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)