### PR TITLE
feat: Center weekday/hour charts in single view

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3,8 +3,10 @@
 use crate::stats::ActivityStats;
 use crate::tui::app::{App, ChartType, Metric};
 use crate::tui::widgets::{
-    render_diverging_bar_chart, render_line_chart_for_metric, render_vertical_bar_chart,
+    chart_width, render_diverging_bar_chart, render_line_chart_for_metric,
+    render_vertical_bar_chart,
 };
+use ratatui::layout::Flex;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
@@ -60,8 +62,22 @@ fn render_single_chart(frame: &mut Frame, area: Rect, app: &App) {
             render_line_chart_for_metric(frame, area, app, Metric::FilesChanged);
         }
         ChartType::AddDel => render_diverging_bar_chart(frame, area, app),
-        ChartType::Weekday => render_weekday_chart(frame, area, &app.activity_stats),
-        ChartType::Hour => render_hourly_chart(frame, area, &app.activity_stats),
+        ChartType::Weekday => {
+            let centered = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Max(chart_width(7))])
+                .flex(Flex::Center)
+                .split(area)[0];
+            render_weekday_chart(frame, centered, &app.activity_stats);
+        }
+        ChartType::Hour => {
+            let centered = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Max(chart_width(24))])
+                .flex(Flex::Center)
+                .split(area)[0];
+            render_hourly_chart(frame, centered, &app.activity_stats);
+        }
     }
 }
 

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -8,4 +8,4 @@ mod vertical_bar_chart;
 pub use diverging_bar_chart::render_diverging_bar_chart;
 pub use horizontal_bar_chart::{BarDataPoint, render_horizontal_bar_chart};
 pub use line_chart::render_line_chart_for_metric;
-pub use vertical_bar_chart::render_vertical_bar_chart;
+pub use vertical_bar_chart::{chart_width, render_vertical_bar_chart};

--- a/src/tui/widgets/vertical_bar_chart.rs
+++ b/src/tui/widgets/vertical_bar_chart.rs
@@ -3,6 +3,22 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders};
 
+/// Bar width in characters
+pub const BAR_WIDTH: u16 = 3;
+/// Gap between bars in characters
+pub const BAR_GAP: u16 = 1;
+/// Border width (left + right)
+const BORDER_WIDTH: u16 = 2;
+
+/// Calculate the minimum width needed to display a vertical bar chart
+#[must_use]
+pub const fn chart_width(bar_count: u16) -> u16 {
+    if bar_count == 0 {
+        return BORDER_WIDTH;
+    }
+    (BAR_WIDTH + BAR_GAP) * bar_count - BAR_GAP + BORDER_WIDTH
+}
+
 /// Render a vertical bar chart
 pub fn render_vertical_bar_chart(
     frame: &mut Frame,
@@ -37,8 +53,8 @@ pub fn render_vertical_bar_chart(
                 .border_style(Style::default().fg(Color::White)),
         )
         .data(BarGroup::default().bars(&bars))
-        .bar_width(3)
-        .bar_gap(1)
+        .bar_width(BAR_WIDTH)
+        .bar_gap(BAR_GAP)
         .max(u64::from(max_value));
 
     frame.render_widget(chart, area);


### PR DESCRIPTION
## Summary
- Single view の Weekday/Hour チャートを中央寄せ + 最大幅制限で表示
- `Layout::flex(Flex::Center)` + `Constraint::Max` を使用
- バー設定から最大幅を計算する `chart_width()` 関数を追加

## Changes
- `src/tui/widgets/vertical_bar_chart.rs`: `BAR_WIDTH`, `BAR_GAP` 定数と `chart_width()` 関数を追加
- `src/tui/ui.rs`: Single view の Weekday/Hour で中央寄せを適用

## Test plan
- [x] `cargo test` 全99テスト通過
- [x] `cargo clippy` 警告なし
- [ ] `cargo run -- --single-metric` で動作確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)