### PR TITLE
perf: Parallelize git repository loading with rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ dirs = "5.0"
 # Progress indicator
 indicatif = "0.18.3"
 
+# Parallel processing
+rayon = "1.10"
+
 [dev-dependencies]
 tempfile = "3.14"
 assert_cmd = "2.0"


### PR DESCRIPTION
## Summary

- 複数リポジトリの `.git` 読み込みを rayon で並列化
- リポジトリ数が増えても処理時間が線形に増加しなくなる

## Changes

- `Cargo.toml`: rayon 1.10 依存追加
- `src/cli/run.rs`: 逐次 for ループを `par_iter()` に置換
- 複数リポジトリの並列処理テスト追加

## Test plan

- [x] `cargo test` - 100 テスト通過
- [x] `cargo clippy` - 警告なし
- [x] pre-commit hook 通過
- [x] 複数リポジトリでの並列処理テスト追加

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)