### PR TITLE
docs: Add -o short option usage examples and tests

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,6 +47,9 @@ cargo install --path .
 # 設定された全リポジトリを分析（過去7日間、TUIモード）
 kodo
 
+# 短縮オプションで TUI 出力
+kodo -o tui
+
 # 特定のリポジトリのみ分析
 kodo --repo-name myproject,another-repo --days 7
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ cargo install --path .
 # Analyze all configured repositories (last 7 days, TUI mode)
 kodo
 
+# TUI output with short option
+kodo -o tui
+
 # Analyze specific repositories by name
 kodo --repo-name myproject,another-repo --days 7
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -146,6 +146,7 @@ impl std::fmt::Display for Period {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn test_output_format_display() {
@@ -188,6 +189,12 @@ mod tests {
     #[test]
     fn test_args_output_tui_explicit() {
         let args = Args::parse_from(["kodo", "--output", "tui"]);
+        assert_eq!(args.output, OutputFormat::Tui);
+    }
+
+    #[test]
+    fn test_args_output_tui_short() {
+        let args = Args::parse_from(["kodo", "-o", "tui"]);
         assert_eq!(args.output, OutputFormat::Tui);
     }
 
@@ -257,5 +264,11 @@ mod tests {
         if let Some(Command::List(list_args)) = args.command {
             assert!(list_args.json);
         }
+    }
+
+    #[test]
+    fn test_help_includes_output_short() {
+        let help = Args::command().render_help().to_string();
+        assert!(help.contains("-o, --output <OUTPUT>"));
     }
 }


### PR DESCRIPTION
## Summary
- Add usage example for `kodo -o tui` in README.md and README.ja.md
- Add test for parsing `-o tui` short option
- Add test to verify `-o, --output` appears in help output

## Test plan
- [x] `cargo test` passes
- [x] `kodo --help` shows `-o, --output <OUTPUT>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)