### PR TITLE
chore: Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-02-11
+
+### Added
+
+- `-o` short option usage examples in README
+
+### Changed
+
+- Default output format changed from TUI to table
+- TUI refactored to Elm-like MVU (Model-View-Update) architecture
+- Parallelized git repository loading with rayon for improved performance
+- Centered weekday/hour charts in single view mode
+- Use local timezone for activity statistics
+
+### Fixed
+
+- Added ratatui snapshot tests for TUI components
+
 ## [0.5.0] - 2026-02-09
 
 ### Added
@@ -77,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/yumazak/kodo/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kodo"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.93"
 authors = ["yumazak"]

--- a/website/docs/en/changelog.md
+++ b/website/docs/en/changelog.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-02-11
+
+### Added
+
+- `-o` short option usage examples in README
+
+### Changed
+
+- Default output format changed from TUI to table
+- TUI refactored to Elm-like MVU (Model-View-Update) architecture
+- Parallelized git repository loading with rayon for improved performance
+- Centered weekday/hour charts in single view mode
+- Use local timezone for activity statistics
+
+### Fixed
+
+- Added ratatui snapshot tests for TUI components
+
 ## [0.5.0] - 2026-02-09
 
 ### Added
@@ -77,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/yumazak/kodo/compare/v0.2.0...v0.3.0

--- a/website/docs/ja/changelog.md
+++ b/website/docs/ja/changelog.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-02-11
+
+### Added
+
+- `-o` short option usage examples in README
+
+### Changed
+
+- Default output format changed from TUI to table
+- TUI refactored to Elm-like MVU (Model-View-Update) architecture
+- Parallelized git repository loading with rayon for improved performance
+- Centered weekday/hour charts in single view mode
+- Use local timezone for activity statistics
+
+### Fixed
+
+- Added ratatui snapshot tests for TUI components
+
 ## [0.5.0] - 2026-02-09
 
 ### Added
@@ -77,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/yumazak/kodo/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
## Release v0.6.0

### Changes
- Version bump to 0.6.0
- Updated CHANGELOG.md

### Highlights
- Default output format changed from TUI to table
- TUI refactored to Elm-like MVU architecture
- Parallelized git repository loading with rayon
- Local timezone support for activity statistics
- Added ratatui snapshot tests

### Checklist
- [ ] CI passes
- [ ] Version in Cargo.toml is correct
- [ ] CHANGELOG.md is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)