### PR TITLE
feat: Show loading spinner for all output modes

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -83,8 +83,8 @@ pub fn execute(args: Args) -> Result<()> {
     }
 
     // Default: analyze repositories
-    // Create spinner for TUI output (RAII ensures cleanup on error)
-    let spinner = SpinnerGuard::new(matches!(args.output, OutputFormat::Tui));
+    // Create spinner for all output modes (RAII ensures cleanup on error)
+    let spinner = SpinnerGuard::new(true);
 
     // Get repositories to analyze
     let repos = get_repositories(&args)?;
@@ -556,6 +556,50 @@ mod tests {
             days: 7,
             include_merges: false,
             output: OutputFormat::Json,
+            period: crate::cli::args::Period::Daily,
+            branch: None,
+            ext: None,
+            single_metric: false,
+            repo_name: None,
+        };
+
+        let result = execute(args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_execute_with_repo_arg_table_output() {
+        let dir = create_test_repo();
+
+        let args = Args {
+            command: None,
+            config: None,
+            repo: Some(dir.path().to_path_buf()),
+            days: 7,
+            include_merges: false,
+            output: OutputFormat::Table,
+            period: crate::cli::args::Period::Daily,
+            branch: None,
+            ext: None,
+            single_metric: false,
+            repo_name: None,
+        };
+
+        let result = execute(args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_execute_with_repo_arg_csv_output() {
+        let dir = create_test_repo();
+
+        let args = Args {
+            command: None,
+            config: None,
+            repo: Some(dir.path().to_path_buf()),
+            days: 7,
+            include_merges: false,
+            output: OutputFormat::Csv,
             period: crate::cli::args::Period::Daily,
             branch: None,
             ext: None,

--- a/tests/output_spinner.rs
+++ b/tests/output_spinner.rs
@@ -1,0 +1,98 @@
+use serde_json::Value;
+use std::process::Command as ProcessCommand;
+use tempfile::TempDir;
+
+fn create_test_repo() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let path = dir.path();
+
+    ProcessCommand::new("git")
+        .args(["init"])
+        .current_dir(path)
+        .output()
+        .expect("git init");
+
+    ProcessCommand::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(path)
+        .output()
+        .expect("git config email");
+
+    ProcessCommand::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(path)
+        .output()
+        .expect("git config name");
+
+    std::fs::write(path.join("README.md"), "# Test\n").expect("write file");
+
+    ProcessCommand::new("git")
+        .args(["add", "."])
+        .current_dir(path)
+        .output()
+        .expect("git add");
+
+    ProcessCommand::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(path)
+        .output()
+        .expect("git commit");
+
+    dir
+}
+
+#[test]
+fn json_output_does_not_include_spinner_text() {
+    let dir = create_test_repo();
+
+    let output = ProcessCommand::new(env!("CARGO_BIN_EXE_kodo"))
+        .args([
+            "--repo",
+            dir.path().to_str().expect("repo path"),
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("run kodo");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid json stdout");
+    assert!(parsed.is_object());
+
+    assert!(!stdout.contains("Loading repositories..."));
+    assert!(!stdout.contains("Collecting commits..."));
+    assert!(!stdout.contains("Calculating statistics..."));
+
+    // Non-TTY test environment may hide spinner output automatically.
+    assert!(!stderr.contains('{'));
+}
+
+#[test]
+fn csv_output_does_not_include_spinner_text() {
+    let dir = create_test_repo();
+
+    let output = ProcessCommand::new(env!("CARGO_BIN_EXE_kodo"))
+        .args([
+            "--repo",
+            dir.path().to_str().expect("repo path"),
+            "--output",
+            "csv",
+        ])
+        .output()
+        .expect("run kodo");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+
+    assert!(stdout.contains("date,commits,additions,deletions,net_lines,files_changed"));
+    assert!(!stdout.contains("Loading repositories..."));
+    assert!(!stdout.contains("Collecting commits..."));
+    assert!(!stdout.contains("Calculating statistics..."));
+
+    // Non-TTY test environment may hide spinner output automatically.
+    assert!(!stderr.contains("period,commits,insertions"));
+}


### PR DESCRIPTION
## Summary
- Enable loading spinner for all output modes (table/json/csv/tui)
- Previously, spinner was only shown for TUI mode
- Spinner outputs to stderr, keeping stdout clean for machine-readable output

## Changes
- `src/cli/run.rs`: Change spinner condition from `OutputFormat::Tui` to always enabled
- `tests/output_spinner.rs`: Add integration tests to verify JSON/CSV stdout is not polluted

## Test plan
- [x] `cargo test --all-targets` passes
- [x] JSON output is valid JSON (no spinner text in stdout)
- [x] CSV output has correct headers (no spinner text in stdout)
- [x] Non-TTY environment automatically hides spinner (indicatif default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)