### PR TITLE
chore: Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-02-11
+
+### Changed
+
+- Show loading spinner for all output modes (table/json/csv/tui)
+- Spinner outputs to stderr, keeping stdout clean for machine-readable output
+
 ## [0.6.0] - 2026-02-11
 
 ### Added
@@ -95,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/yumazak/kodo/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kodo"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.93"
 authors = ["yumazak"]

--- a/website/docs/en/changelog.md
+++ b/website/docs/en/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-02-11
+
+### Changed
+
+- Show loading spinner for all output modes (table/json/csv/tui)
+- Spinner outputs to stderr, keeping stdout clean for machine-readable output
+
 ## [0.6.0] - 2026-02-11
 
 ### Added
@@ -95,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/yumazak/kodo/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0

--- a/website/docs/ja/changelog.md
+++ b/website/docs/ja/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-02-11
+
+### Changed
+
+- Show loading spinner for all output modes (table/json/csv/tui)
+- Spinner outputs to stderr, keeping stdout clean for machine-readable output
+
 ## [0.6.0] - 2026-02-11
 
 ### Added
@@ -95,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/yumazak/kodo/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/yumazak/kodo/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
## Release v0.6.1

### Changes
- Version bump to 0.6.1
- Updated CHANGELOG.md

### Highlights
- Show loading spinner for all output modes (table/json/csv/tui)
- Spinner outputs to stderr, keeping stdout clean for machine-readable output

### Checklist
- [ ] CI passes
- [ ] Version in Cargo.toml is correct
- [ ] CHANGELOG.md is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)