### PR TITLE
release: 0.6.2 (#30 #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-02-15
+
+### Added
+
+- `--timezone` option for aggregation timezone (`local`, `utc`, or IANA timezone like `America/New_York`)
+- DST-aware timezone handling utilities with tests for named timezone offset changes
+
+### Changed
+
+- Aggregate daily stats and activity charts using the selected timezone instead of fixed UTC assumptions
+
+### Fixed
+
+- Cloudflare Pages setup guide now includes steps to disable PR preview deployments when only main-branch deploys are desired
+
 ## [0.6.1] - 2026-02-11
 
 ### Changed
@@ -102,7 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default output format to TUI mode
 - Removed x86_64-apple-darwin target from release workflow
 
-[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/yumazak/kodo/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/yumazak/kodo/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/yumazak/kodo/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/yumazak/kodo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/yumazak/kodo/compare/v0.4.0...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kodo"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.93"
 authors = ["yumazak"]
@@ -30,6 +30,7 @@ serde_json = "1.0"
 
 # Date/Time
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 
 # Git
 git2 = "0.19"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ kodo --ext rs,ts,js --days 7
 # Weekly aggregation
 kodo --period weekly --days 30
 
+# DST-aware timezone aggregation (IANA timezone)
+kodo --timezone America/New_York --days 30
+
 # Single metric view (default is split view)
 kodo --single-metric
 ```
@@ -122,6 +125,7 @@ Create a config file at `~/.config/kodo/config.json`:
 | `--ext` | | File extensions to include (comma-separated) | All files |
 | `--include-merges` | | Include merge commits | false |
 | `--single-metric` | | Show single metric in TUI | false (split view) |
+| `--timezone` | | Timezone for aggregation (`local`, `utc`, or IANA TZ like `Asia/Tokyo`) | local |
 | `--repo-name` | | Filter repositories by name (comma-separated) | All repos |
 
 ## Metrics

--- a/benches/git_stats.rs
+++ b/benches/git_stats.rs
@@ -11,7 +11,7 @@ use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_ma
 use kodo::cli::args::Period;
 use kodo::config::{default_config_path, expand_tilde, load_config};
 use kodo::git::Repository;
-use kodo::stats::{DateRange, Days, collect_stats};
+use kodo::stats::{DateRange, Days, TimeZoneMode, collect_stats};
 use std::env;
 use std::path::PathBuf;
 
@@ -120,6 +120,7 @@ fn bench_collect_stats(c: &mut Criterion) {
     println!("Benchmarking collect_stats with {} commits", commits.len());
 
     let mut group = c.benchmark_group("collect_stats");
+    let timezone = TimeZoneMode::Local;
 
     group.bench_function("daily", |b| {
         b.iter(|| {
@@ -129,6 +130,7 @@ fn bench_collect_stats(c: &mut Criterion) {
                 black_box(range),
                 black_box(Period::Daily),
                 None,
+                black_box(&timezone),
             )
         });
     });
@@ -141,6 +143,7 @@ fn bench_collect_stats(c: &mut Criterion) {
                 black_box(range),
                 black_box(Period::Weekly),
                 None,
+                black_box(&timezone),
             )
         });
     });

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -47,6 +47,10 @@ pub struct Args {
     #[arg(long)]
     pub single_metric: bool,
 
+    /// Timezone for date/activity aggregation: local, utc, or IANA tz (e.g. Asia/Tokyo)
+    #[arg(long, default_value = "local")]
+    pub timezone: String,
+
     /// Filter repositories by name (comma-separated, from config)
     #[arg(long, value_delimiter = ',')]
     pub repo_name: Option<Vec<String>>,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -89,7 +89,8 @@ pub fn execute(args: Args) -> Result<()> {
     // Get repositories to analyze
     let repos = get_repositories(&args)?;
 
-    let timezone = TimeZoneMode::parse(&args.timezone).map_err(|message| Error::ConfigInvalid { message })?;
+    let timezone =
+        TimeZoneMode::parse(&args.timezone).map_err(|message| Error::ConfigInvalid { message })?;
 
     // Calculate date range
     let to = timezone.now_date_naive();

--- a/src/stats/collector.rs
+++ b/src/stats/collector.rs
@@ -170,8 +170,8 @@ pub fn collect_activity_stats(commits: &[CommitInfo], timezone: &TimeZoneMode) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stats::timezone::TimeZoneMode;
     use crate::git::{DiffStats, FileChange};
+    use crate::stats::timezone::TimeZoneMode;
     use chrono::{TimeZone, Utc};
 
     fn make_commit(date: NaiveDate, additions: u64, deletions: u64) -> CommitInfo {
@@ -191,7 +191,14 @@ mod tests {
             NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(),
         );
 
-        let result = collect_stats("test", vec![], range, Period::Daily, None, &TimeZoneMode::Local);
+        let result = collect_stats(
+            "test",
+            vec![],
+            range,
+            Period::Daily,
+            None,
+            &TimeZoneMode::Local,
+        );
 
         assert_eq!(result.repository, "test");
         assert_eq!(result.stats.len(), 3); // 3 days with zeros
@@ -210,7 +217,14 @@ mod tests {
         ];
 
         let range = DateRange::new(date1, date2);
-        let result = collect_stats("test", commits, range, Period::Daily, None, &TimeZoneMode::Local);
+        let result = collect_stats(
+            "test",
+            commits,
+            range,
+            Period::Daily,
+            None,
+            &TimeZoneMode::Local,
+        );
 
         assert_eq!(result.stats.len(), 2);
         assert_eq!(result.total.commits, 3);

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -3,7 +3,9 @@
 pub mod aggregator;
 pub mod collector;
 pub mod types;
+pub mod timezone;
 
 pub use aggregator::{filter_non_zero, merge_stats, running_totals};
 pub use collector::{collect_activity_stats, collect_stats};
+pub use timezone::TimeZoneMode;
 pub use types::{ActivityStats, AnalysisResult, DateRange, Days, PeriodStats, TotalStats};

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -2,8 +2,8 @@
 
 pub mod aggregator;
 pub mod collector;
-pub mod types;
 pub mod timezone;
+pub mod types;
 
 pub use aggregator::{filter_non_zero, merge_stats, running_totals};
 pub use collector::{collect_activity_stats, collect_stats};

--- a/src/stats/timezone.rs
+++ b/src/stats/timezone.rs
@@ -9,6 +9,11 @@ pub enum TimeZoneMode {
 }
 
 impl TimeZoneMode {
+    /// Parse timezone mode from CLI input.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when input is neither `local`, `utc`, nor a valid IANA timezone name.
     pub fn parse(input: &str) -> Result<Self, String> {
         let normalized = input.trim();
         if normalized.eq_ignore_ascii_case("local") {
@@ -18,12 +23,12 @@ impl TimeZoneMode {
             return Ok(Self::Utc);
         }
 
-        normalized
-            .parse::<Tz>()
-            .map(Self::Named)
-            .map_err(|_| format!("invalid timezone: {input}. Use local, utc, or an IANA name like Asia/Tokyo"))
+        normalized.parse::<Tz>().map(Self::Named).map_err(|_| {
+            format!("invalid timezone: {input}. Use local, utc, or an IANA name like Asia/Tokyo")
+        })
     }
 
+    #[must_use]
     pub fn date_naive(&self, utc: DateTime<Utc>) -> chrono::NaiveDate {
         match self {
             Self::Local => utc.with_timezone(&Local).date_naive(),
@@ -32,6 +37,7 @@ impl TimeZoneMode {
         }
     }
 
+    #[must_use]
     pub fn datetime(&self, utc: DateTime<Utc>) -> DateTime<chrono::FixedOffset> {
         match self {
             Self::Local => utc.with_timezone(&Local).fixed_offset(),
@@ -40,6 +46,7 @@ impl TimeZoneMode {
         }
     }
 
+    #[must_use]
     pub fn now_date_naive(&self) -> chrono::NaiveDate {
         match self {
             Self::Local => Local::now().date_naive(),

--- a/src/stats/timezone.rs
+++ b/src/stats/timezone.rs
@@ -1,0 +1,75 @@
+use chrono::{DateTime, Local, Utc};
+use chrono_tz::Tz;
+
+#[derive(Debug, Clone)]
+pub enum TimeZoneMode {
+    Local,
+    Utc,
+    Named(Tz),
+}
+
+impl TimeZoneMode {
+    pub fn parse(input: &str) -> Result<Self, String> {
+        let normalized = input.trim();
+        if normalized.eq_ignore_ascii_case("local") {
+            return Ok(Self::Local);
+        }
+        if normalized.eq_ignore_ascii_case("utc") {
+            return Ok(Self::Utc);
+        }
+
+        normalized
+            .parse::<Tz>()
+            .map(Self::Named)
+            .map_err(|_| format!("invalid timezone: {input}. Use local, utc, or an IANA name like Asia/Tokyo"))
+    }
+
+    pub fn date_naive(&self, utc: DateTime<Utc>) -> chrono::NaiveDate {
+        match self {
+            Self::Local => utc.with_timezone(&Local).date_naive(),
+            Self::Utc => utc.date_naive(),
+            Self::Named(tz) => utc.with_timezone(tz).date_naive(),
+        }
+    }
+
+    pub fn datetime(&self, utc: DateTime<Utc>) -> DateTime<chrono::FixedOffset> {
+        match self {
+            Self::Local => utc.with_timezone(&Local).fixed_offset(),
+            Self::Utc => utc.fixed_offset(),
+            Self::Named(tz) => utc.with_timezone(tz).fixed_offset(),
+        }
+    }
+
+    pub fn now_date_naive(&self) -> chrono::NaiveDate {
+        match self {
+            Self::Local => Local::now().date_naive(),
+            Self::Utc => Utc::now().date_naive(),
+            Self::Named(tz) => Utc::now().with_timezone(tz).date_naive(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn parses_named_timezone() {
+        let tz = TimeZoneMode::parse("America/New_York").expect("valid timezone");
+        assert!(matches!(tz, TimeZoneMode::Named(_)));
+    }
+
+    #[test]
+    fn handles_dst_offsets_for_named_timezone() {
+        let tz = TimeZoneMode::parse("America/New_York").expect("valid timezone");
+
+        let winter = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+        let summer = Utc.with_ymd_and_hms(2024, 7, 15, 12, 0, 0).unwrap();
+
+        let winter_offset = tz.datetime(winter).offset().local_minus_utc();
+        let summer_offset = tz.datetime(summer).offset().local_minus_utc();
+
+        assert_ne!(winter_offset, summer_offset);
+    }
+}

--- a/website/CLOUDFLARE_SETUP.md
+++ b/website/CLOUDFLARE_SETUP.md
@@ -49,9 +49,18 @@ Click **Save and Deploy**. Cloudflare will build and deploy your site.
 
 ## Automatic Deployments
 
-After initial setup, Cloudflare Pages will automatically deploy when:
-- Pushing to the `main` branch
-- Creating a pull request (preview deployment)
+By default, Cloudflare Pages deploys on:
+- Push to the production branch (`main`)
+- Pull requests (Preview deployments)
+
+To avoid deployments for every PR (issue #30), configure the project as follows:
+
+1. Open **Workers & Pages** → your project → **Settings** → **Builds & deployments**
+2. Set **Production branch** to `main`
+3. Disable **Preview deployments** (or limit preview branch patterns)
+4. Optional: in **Build watch paths**, include only `website/**` so non-doc changes do not trigger deploys
+
+This keeps production deploys tied to `main` merges while avoiding unnecessary PR preview builds.
 
 ## Custom Domain (Optional)
 


### PR DESCRIPTION
## Summary

Prepare v0.6.2 release with fixes for #30 and #44.

### Included
- feat: add `--timezone` (`local`/`utc`/IANA) for DST-aware aggregation
- refactor: apply selected timezone to daily stats + activity charts
- docs: Cloudflare Pages setup guidance to avoid deploys on every PR
- chore: bump version to 0.6.2 and update changelog

Closes #30
Closes #44